### PR TITLE
Bug Fix: editor is null in Code notes

### DIFF
--- a/Swap Enter.js
+++ b/Swap Enter.js
@@ -19,7 +19,7 @@ class ChangeConfigWidget extends api.NoteContextAwareWidget {
         this.editorIntervalId = setInterval(async () => {
             const editor = await api.getActiveContextTextEditor();
             clearInterval(this.editorIntervalId);
-            if (this.initializedEditorIds.includes(editor.id)) {
+            if (!editor || this.initializedEditorIds.includes(editor.id)) {
                 return;
             }
             this.initializedEditorIds.push(editor.id);


### PR DESCRIPTION
editor is null in Code notes

```
JS Error: Uncaught error: Message: Cannot read properties of null (reading 'id'), Line: undefined, Column: undefined, Error object: {}, Stack: TypeError: Cannot read properties of null (reading 'id')
    at eval (eval at <anonymous> (http://127.0.0.1:37840/assets/v0.92.4/app-dist/desktop.js:2:7922), <anonymous>:26:59)
```